### PR TITLE
fix blank message issue

### DIFF
--- a/handlers/slashCommands.js
+++ b/handlers/slashCommands.js
@@ -24,6 +24,7 @@ const slashChannel = async ({
       user: user_id,
       text: ":thinking_face: Maybe try actually writing something?"
     });
+    return;
   }
   switch (channel_name) {
     case "general":


### PR DESCRIPTION
This fixes an issue where a user could request `/channel` with nothing else and it will either 1) send a blank message if they're not in a locked channel, or 2) send a request to the mods if they are in a locked channel.