### PR TITLE
feat: strip emojis from at-channel message text

### DIFF
--- a/handlers/slashCommands.js
+++ b/handlers/slashCommands.js
@@ -1,5 +1,6 @@
 //node packages
 const md5 = require("md5");
+const emojiRegex = require("emoji-regex")();
 
 //local packages
 const {
@@ -17,6 +18,7 @@ const TOKEN = process.env.SLACK_BOT_TOKEN;
 const slashChannel = async ({
   command: { channel_name, channel_id, user_id, text }
 }) => {
+  text = text.replace(emojiRegex, "");
   if (text == "" || text == "&gt;" || text == "&gt;&gt;&gt;") {
     postEphemeral({
       token: TOKEN,

--- a/package-lock.json
+++ b/package-lock.json
@@ -850,9 +850,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -3511,6 +3511,13 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "emoji-regex": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+            }
           }
         },
         "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@slack/bolt": "^1.2.0",
     "dotenv": "^8.0.0",
+    "emoji-regex": "^8.0.0",
     "eslint": "^6.0.1",
     "md5": "^2.2.1"
   },

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 require("dotenv").config();
 
 //local packages
+const emojiRegex = require("emoji-regex")();
 const { app } = require("./utilities/bolt.js");
 const { isModerator } = require("./utilities/helperFunctions.js");
 const { slashChannel } = require("./handlers/slashCommands.js");
@@ -38,7 +39,7 @@ app.action(
       .exec(blocks[0].text.text)[0]
       .replace("<#", "")
       .replace(">", "");
-    const text = blocks[1].text.text.replace("&gt;&gt;&gt;", "");
+    const text = blocks[1].text.text.replace("&gt;&gt;&gt;", "").replace(emojiRegex, "");
     const user_id = /<@(.*?)[a-zA-Z0-9]{7,10}>/
       .exec(blocks[0].text.text)[0]
       .replace("<@", "")

--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@
 require("dotenv").config();
 
 //local packages
-const emojiRegex = require("emoji-regex")();
 const { app } = require("./utilities/bolt.js");
 const { isModerator } = require("./utilities/helperFunctions.js");
 const { slashChannel } = require("./handlers/slashCommands.js");
@@ -39,7 +38,7 @@ app.action(
       .exec(blocks[0].text.text)[0]
       .replace("<#", "")
       .replace(">", "");
-    const text = blocks[1].text.text.replace("&gt;&gt;&gt;", "").replace(emojiRegex, "");
+    const text = blocks[1].text.text.replace("&gt;&gt;&gt;", "");
     const user_id = /<@(.*?)[a-zA-Z0-9]{7,10}>/
       .exec(blocks[0].text.text)[0]
       .replace("<@", "")


### PR DESCRIPTION
Uses [emoji-regex](https://www.npmjs.com/package/emoji-regex) to give us the regex necessary for removing unicode emojis.