### PR TITLE
Convert Dockerfile to use 12-alpine instead of 12-stretch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.github/
+node_modules/
+.drone.yml
+.env.example
+.eslintrc.json
+.gitignore
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM node:latest
+FROM node:12-alpine
+
 RUN mkdir -p /usr/src/app
+
 WORKDIR /usr/src/app
-COPY package*.json /usr/src/app/
-RUN npm install
+
 COPY . /usr/src/app/
+
+RUN npm install
+
 EXPOSE 3000
+
 CMD npm start


### PR DESCRIPTION
Additionally adds a `.dockerignore` to ignore any files not strictly necessary for running the thing and one extra run layer.